### PR TITLE
adding 'vendor' to NFD config to support Nvidia GPU discovery

### DIFF
--- a/ansible/roles/install_rhoai_components/tasks/install_nfd.yaml
+++ b/ansible/roles/install_rhoai_components/tasks/install_nfd.yaml
@@ -71,3 +71,4 @@
                   - "12"
                 deviceLabelFields:
                   - "class"
+                  - "vendor"


### PR DESCRIPTION
This got dropped in between a couple of branches being worked at the same time, but it needs to be present for NFD to properly label any nodes with NVidia GPUs.